### PR TITLE
Implementado  no Dockerfile, novo container PhpmyAd

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.4'
+version: "3.4"
 
 services:
   php:
@@ -36,8 +36,17 @@ services:
       - ./app:/srv/app
       - ./.docker/nginx:/etc/nginx/conf.d
     ports:
-      - "8080:80"
+      - "80:80"
     depends_on:
       - php
+
+  phpmyadmin:
+    image: phpmyadmin
+    restart: always
+    ports:
+      - 8080:80
+    environment:
+      - PMA_ARBITRARY=1
+
 volumes:
   data:


### PR DESCRIPTION
Se precisar de SGDB, pode usar o gerenciador de banco, o Phpmyadmin, especificando no servidor o "db". após subir os containeres, acesse pelo: localhost:8080

Issue: _link_or_issue_number_here

#### Description

_brief_description_here_

#### Testing

_steps_to_test_code_here_