### PR TITLE
generate a more secure salt and fix nginx permissions issue

### DIFF
--- a/.docker/php/docker-entrypoint.sh
+++ b/.docker/php/docker-entrypoint.sh
@@ -24,7 +24,7 @@ if [ "$1" = 'php-fpm' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/cakephp' ]; then
 
         sed -i '/export APP_NAME/c\export APP_NAME="cakephp"' config/.env
 
-        salt=$(cat /dev/urandom | LC_CTYPE=C tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
+        salt=$(openssl rand -base64 32)
         sed -i '/export SECURITY_SALT/c\export SECURITY_SALT="'$salt'"' config/.env
 
         touch .gitkeep
@@ -37,9 +37,10 @@ if [ "$1" = 'php-fpm' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/cakephp' ]; then
 
     mkdir -p logs tmp
 
-    echo "HOST OS: "$HOST_OS""
-    if ["$HOST_OS" = 'Linux']; then
-        echo "setting ACLs..."
+    # Set ACLs for Linux users
+    echo "HOST OS: $HOST_OS"
+    if [[ $HOST_OS == *"Linux"* ]]; then
+        echo "Setting ACLs..."
         setfacl -R -m u:www-data:rwX -m u:"$(whoami)":rwX logs
         setfacl -R -m u:www-data:rwX -m u:"$(whoami)":rwX tmp
         setfacl -R -m g:nginx:rwX /srv/app

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,3 @@ jobs:
         run: curl -f -v -o /dev/null http://localhost:8080
       - name: Check NGINX Files
         run: curl -f -v -o /dev/null http://localhost:8080/css/home.css
-
-
-  STATUSCODE=$(curl --silent --output /dev/stderr --write-out "%{http_code}" http://localhost:8080/css/home.css)
-
-  if test $STATUSCODE -ne 200; then
-  exit 1
-  fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Start
         run: docker-compose up -d
       - name: Wait for services
-        run: sleep 5
+        run: sleep 10
       - name: Check CakePHP Welcome Page
         run: curl -f -v -o /dev/null http://localhost:8080
       - name: Check NGINX Files

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,5 +21,7 @@ jobs:
         run: docker-compose up -d
       - name: Wait for services
         run: sleep 5
-      - name: HTTP Check
+      - name: Check CakePHP Welcome Page
         run: curl -v -o /dev/null http://localhost:8080
+      - name: Check NGINX Files
+        run: curl -v -o /dev/null http://localhost:8080/css/home.css

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,13 @@ jobs:
       - name: Wait for services
         run: sleep 5
       - name: Check CakePHP Welcome Page
-        run: curl -v -o /dev/null http://localhost:8080
+        run: curl -f -v -o /dev/null http://localhost:8080
       - name: Check NGINX Files
-        run: curl -v -o /dev/null http://localhost:8080/css/home.css
+        run: curl -f -v -o /dev/null http://localhost:8080/css/home.css
+
+
+  STATUSCODE=$(curl --silent --output /dev/stderr --write-out "%{http_code}" http://localhost:8080/css/home.css)
+
+  if test $STATUSCODE -ne 200; then
+  exit 1
+  fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,10 @@ COPY .assets /srv/.assets
 
 WORKDIR /srv/app
 
-RUN addgroup -g 101 nginx
 RUN adduser --disabled-password --gecos '' -u $UID cakephp;
+RUN addgroup -g 101 nginx
+RUN addgroup cakephp nginx
+RUN addgroup cakephp www-data
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 


### PR DESCRIPTION
- Use `openssl` to generate initial salt value
- Fix nginx permissions issue (on linux host os) causing webroot assets to not load.
- Adds checking webroot assets do not 404 to github actoin